### PR TITLE
修复：上次更新中的遗留问题

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,26 +89,28 @@ onBeforeUnmount(() => {
 </div>
 
 <div class="homepage-recommend">
-    <div class="homepage-recommend-item">
-        <SmallTitle>你知道吗</SmallTitle>
-        <ul>
-            <li><a href="/upgrade/0785-Lavaloon-Puppet">熔岩气球玩偶</a> 是目前游戏中唯一召唤临时兵种的装备。</li>
-            <li><a href="/upgrade/0488-Blacksmith">铁匠铺</a> 免疫 <a href="/upgrade/0100-Lightning-Spell">雷电法术</a> 伤害，理论上属于资源类建筑，但不被 <a href="/upgrade/0003-Goblin">哥布林</a> 优先攻击。</li>
-            <li>在远古版本，<a href="/upgrade/110a-Giant-Cannon">巨型加农炮</a> 会对 <a href="/upgrade/10f0-Battle-Machine">战争机器</a> 造成额外伤害。</li>
-            <li>2024 年 9 月更新大幅提高了仓库的 <a href="/p/639">掠夺上限</a>。</li>
-            <li><a href="/p/6524">匹配值</a> 是什么？如何查看？</li>
-        </ul>
-    </div>
-    <div class="homepage-recommend-item">
-        <SmallTitle>最新动态</SmallTitle>
-        <ul>
-            <li>针对 <a href="/upgrade/008a-Druid">德鲁伊</a> 的平衡性调整已于 10/2 上线。</li>
-            <li>九月更新的数据已于 9/12 上线。</li>
-            <li>网站的搜索功能已与 8/7 上线。</li>
-            <li>旧版网站的所有文章已于 6/29 迁移完毕。</li>
-            <li>六月更新数据已于 6/18 上线。</li>
-        </ul>
-    </div>
+<div class="homepage-recommend-item">
+<SmallTitle>你知道吗</SmallTitle>
+        
+- 2024/11 更新后，8 本即可解锁 [女王](/upgrade/0201-Archer-Queen)。
+- [地狱火炮](/upgrade/0315-Inferno-Artillery) 缝合了天鹰火炮、熔岩发射器、多人箭塔、都城大本营等建筑的特点。
+- 游戏中有两位少爷每天只工作一小时：[实验助手](/upgrade/0800-Lab-Assistant) 和 [建筑工人学徒](/upgrade/0801-Builder's-Apprentice)。
+- 在远古版本，[巨型加农炮](/upgrade/110a-Giant-Cannon) 会对 [战争机器](/upgrade/10f0-Battle-Machine) 造成额外伤害。
+- 2022/06 更新后，[部落城堡](/upgrade/0407-Clan-Castle) 开始使用圣水升级。
+
+</div>
+
+<div class="homepage-recommend-item">
+<SmallTitle>最新动态</SmallTitle>
+
+- 17 本版本的数据已于 12/8 上线。本次更新新增的单位有：
+    - 科技：[巨矛投手](/upgrade/0011-Thrower)、[复苏法术](/upgrade/category/home)。
+    - 建筑：[地狱火炮](/upgrade/0315-Inferno-Artillery)、[火焰喷射器](/upgrade/0316-Firespitter)、[终极炸弹](/upgrade/0387-Giga-Bomb)、[英雄殿堂](/upgrade/0489-Hero-Hall)、[帮手小屋](/upgrade/0502-Helper-Hut)。
+    - 英雄相关：[亡灵王子](/upgrade/0204-Minion-Prince)、[护卫玩偶](/upgrade/0720-Henchmen-Puppet)、[暗黑魔球](/upgrade/0721-Dark-Orb)。
+    - 其他：[实验助手](/upgrade/0800-Lab-Assistant)。
+- 针对 [德鲁伊](/upgrade/008a-Druid) 的平衡性调整已于 10/2 上线。
+
+</div>
 </div>
 
 <div class="homepage-attention">

--- a/docs/upgrade/0720-Henchmen-Puppet.md
+++ b/docs/upgrade/0720-Henchmen-Puppet.md
@@ -2,13 +2,20 @@
 title: "部落冲突 coc 护卫玩偶装备升级数据"
 navTitle: "护卫玩偶"
 shownTitle: "护卫玩偶"
-description: ""
+description: "护卫玩偶是亡灵王子的两件初始装备之一，另一件是暗黑魔球。护卫玩偶装备可以让亡灵王子使用技能时召唤出两个空中护卫。激活技能后，亡灵王子会短暂隐身，此时空中护卫的作用就是替英雄扛伤害。"
 module: upgrade-home
 imgFolder: home_heroes/0720
 wiki: https://clashofclans.fandom.com/wiki/Henchmen_Puppet
 canonical: /upgrade/0720-Henchmen-Puppet
 ---
 
+<SwitchTabs contentClass="cp-unit-items" :stickyTabs="true" :pageTabs="true">
+    <SwitchTab tabId="cp-unit-item-0" :activeTab="true">护卫玩偶</SwitchTab>
+    <SwitchTab tabId="cp-unit-item-1">空中护卫</SwitchTab>
+</SwitchTabs>
+
+<!-- ↓↓↓ 护卫玩偶 ↓↓↓ -->
+<SwitchTabGroup id="cp-unit-item-0" class="cp-unit-items">
 <UnitInfo :folder="$frontmatter.imgFolder" imgSrc="Henchmen_Puppet_info.png" :imgAlt="$frontmatter.navTitle" />
 
 <SmallTitle>说明</SmallTitle>
@@ -74,7 +81,54 @@ const tableExtraInfo = [
 
 1. 如果升级费用中有多种资源，则同时需要多种资源才能升级。
 2. 如果玩家升级到了 9 本并解锁了亡灵王子，即使玩家没有马上升 [铁匠铺](/upgrade/0488-Blacksmith) 也可以升级护卫玩偶装备。
+</SwitchTabGroup>
 
+<!-- ↓↓↓ 空中护卫 ↓↓↓ -->
+<SwitchTabGroup id="cp-unit-item-1" class="cp-unit-items">
+<UnitInfo :folder="$frontmatter.imgFolder" imgSrc="Henchmen_info.png" :imgAlt="$frontmatter.navTitle"
+    description="亡灵王子可以召唤这些邪恶的兄弟姐妹与他并肩作战！他们会吸收伤害并攻击防御建筑。" />
+
+<SmallTitle>各等级图片</SmallTitle>
+
+<Panel>
+    <UnitImgGroup :folder="$frontmatter.imgFolder">
+        <UnitImg imgTitle="所有等级" imgSrc="Henchmen1.png" />
+    </UnitImgGroup>
+</Panel>
+
+<SmallTitle>说明</SmallTitle>
+
+空中护卫不能在 [训练营](/upgrade/0481-Barracks) 或 [暗黑训练营](/upgrade/0482-Dark-Barracks) 中直接训练，只能通过亡灵王子召唤。
+
+<SmallTitle>属性</SmallTitle>
+
+<UnitProperties>
+    <UnitProperty pKey="攻击偏好" pValue="无" />
+    <UnitProperty pKey="伤害类型" pValue="单体伤害" />
+    <UnitProperty pKey="攻击的目标" pValue="地面和空中目标" />
+    <UnitProperty pKey="占据人口" pValue="10" />
+    <UnitProperty pKey="移动速度" pValue="4 格/秒" />
+    <UnitProperty pKey="攻击速度" pValue="1.1 秒/次" />
+    <UnitProperty pKey="攻击距离" pValue="1 格" />
+</UnitProperties>
+
+<SmallTitle>升级数据</SmallTitle>
+
+<UnitTable>
+
+| 等级 | 每秒伤害 | 每次伤害 | 生命值 |
+|  --- |   ---   |   ---   |   ---  |
+|   1  |   102   |  112.2  |  1600  |
+|   2  |   110   |  121    |  1700  |
+|   3  |   118   |  129.8  |  1750  |
+|   4  |   126   |  138.6  |  1800  |
+|   5  |   134   |  147.4  |  1950  |
+|   6  |   142   |  156.2  |  2100  |
+|   7  |   150   |  165    |  2500  |
+</UnitTable>
+</SwitchTabGroup>
+
+<!-- ↓↓↓ 公共部分 ↓↓↓ -->
 <SmallTitle>更新历史</SmallTitle>
 
 <Timeline>

--- a/docs/upgrade/category/home.md
+++ b/docs/upgrade/category/home.md
@@ -172,7 +172,7 @@ if (activeTabCookieValue === "home-techniques") {
         <ListItem name="大本营" imgSrc="0400/Town_Hall17_5.png" link="0400-Town-Hall" />
         <ListItem name="巨型特斯拉电磁塔" imgSrc="030c/Giga_Tesla5_thumb.png" link="030c-Giga-Tesla" />
         <ListItem name="巨型地狱之塔" imgSrc="030d/Giga_Inferno16_thumb.png" link="030d-Giga-Inferno" />
-        <ListItem name="巨型地狱之塔" imgSrc="0315/Inferno_Artillery5.png" link="0315-Inferno-Artillery" />
+        <ListItem name="地狱火炮" imgSrc="0315/Inferno_Artillery5.png" link="0315-Inferno-Artillery" />
     </ListItems>
     <ListItems title="防御建筑" imgFolder="home_buildings">
         <ListItem name="城墙" imgSrc="0300/Wall18.png" link="0300-Walls" />


### PR DESCRIPTION
-----
更新：首页推荐内容
修复：升级数据的导航页中将地狱火炮写成巨型地狱之塔的 bug
新增：空中护卫（护卫玩偶装备的派生兵种）的详细数据