### PR TITLE
优化：通知发布逻辑

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,7 +73,8 @@ export default defineConfig({
         },
         resolve: {
             alias: {
-                "@": path.resolve(__dirname, "./theme")
+                "@": path.resolve(__dirname, "./theme"),
+                "#": path.resolve(__dirname, "../..")
             }
         }
     }

--- a/global-variables.js
+++ b/global-variables.js
@@ -1,0 +1,12 @@
+/**
+ * hasNotification {Boolean} 是否发布通知，如果填 false 则视为不发布，前端不再运行通知相关的代码，可节省性能。
+ * notificationCount {Number} 通知角标显示的数字，默认为 1，只有当同时发布多条通知时才需要修改这个值。
+ * currentNotificationId {Number} 当前通知的 ID，前端需要用这个值区分接收到的是全新通知还是以前发布过的通知。发布新通知时请将这个值 +1
+ * notificationHTML {String} 通知内容，可使用 HTML 代码。如果发布多条通知，通常使用 <hr> 标签分割。
+ */
+export const notificationInfo = {
+    "hasNotification": true,
+    "notificationCount": 1,
+    "currentNotificationId": 7,
+    "notificationHTML": "三月更新的数据已更新完毕。"
+}


### PR DESCRIPTION
现在发布通知无需进入 Head.vue 页面了，可直接在 global-variables.js 中完成。